### PR TITLE
standards write speed, UoA collection and metadata fixes

### DIFF
--- a/mth5/clients/metronix.py
+++ b/mth5/clients/metronix.py
@@ -120,7 +120,7 @@ class MetronixClient(ClientBase):
                         run_group.from_channel_ts(ch_ts)
                     run_group.update_metadata()
                 station_group.update_metadata()
-                survey_group.update_metadata
+                survey_group.update_metadata()
 
         self.logger.info(f"Wrote MTH5 file to: {self.save_path}")
 

--- a/mth5/clients/phoenix.py
+++ b/mth5/clients/phoenix.py
@@ -289,7 +289,7 @@ class PhoenixClient(ClientBase):
 
                     run_group.update_metadata()
 
-            station_group.update_metadata()
+                station_group.update_metadata()
             survey_group.update_metadata()
 
         return self.save_path

--- a/mth5/clients/uoa.py
+++ b/mth5/clients/uoa.py
@@ -16,7 +16,7 @@ Created on Thu Nov 7 15:35:00 2025
 # =============================================================================
 from pathlib import Path
 
-from mt_io.uoa import read_orange, read_uoa
+from mt_io.uoa import UoACollection, read_orange, read_uoa
 
 from mth5.clients.base import ClientBase
 from mth5.mth5 import MTH5
@@ -66,16 +66,33 @@ class UoAClient(ClientBase):
 
     """
 
+    # reader arguments the collection also needs
+    _collection_keys = (
+        "sample_rate",
+        "dipole_length_ex",
+        "dipole_length_ey",
+        "latitude",
+        "longitude",
+        "elevation",
+    )
+
     def __init__(
         self,
         data_path,
         save_path=None,
         instrument_type="pr624",
+        sample_rates=None,
         mth5_filename="from_uoa.h5",
         **kwargs,
     ):
+        # EDL carries no header, so the rate usually arrives as sample_rate
+        self.sample_rates_given = sample_rates is not None
         super().__init__(
-            data_path, save_path=save_path, mth5_filename=mth5_filename, **kwargs
+            data_path,
+            save_path=save_path,
+            sample_rates=sample_rates if sample_rates is not None else [1],
+            mth5_filename=mth5_filename,
+            **kwargs,
         )
 
         self.instrument_type = instrument_type.lower()
@@ -84,15 +101,23 @@ class UoAClient(ClientBase):
                 f"instrument_type must be 'pr624' or 'orange', got '{instrument_type}'"
             )
 
+        # the Orange Box writes one file per deployment and has no collection
+        if self.instrument_type == "pr624":
+            self.collection = UoACollection(self.data_path)
+
     def make_mth5_from_uoa(self, survey_id, station_id, run_id="001", **kwargs):
         """
         Create an MTH5 file from UoA instrument data.
 
         :param survey_id: Survey identifier
         :type survey_id: str
+        PR6-24 stations are split into runs on the gaps. The station id comes
+        from the file names, so a mid-deployment rename gives two stations.
+
         :param station_id: Station identifier
         :type station_id: str
-        :param run_id: Run identifier, defaults to "001"
+        :param run_id: Run identifier for the Orange Box, which records one
+         run per deployment. PR6-24 run names come from the collection.
         :type run_id: str, optional
         :param kwargs: Additional keyword arguments for reader:
 
@@ -144,20 +169,19 @@ class UoAClient(ClientBase):
 
         """
 
-        # Read data using appropriate reader
         if self.instrument_type == "pr624":
-            run_ts = read_uoa(self.data_path, station_id=station_id, **kwargs)
-        else:  # orange
-            # For Orange Box, handle both single file and directory
-            data_path = Path(self.data_path)
-            if data_path.is_dir():
-                # Get all .BIN files in directory
-                bin_files = sorted(data_path.glob("*.BIN"))
-                if not bin_files:
-                    raise FileNotFoundError(f"No .BIN files found in {data_path}")
-                run_ts = read_orange(bin_files, station_id=station_id, **kwargs)
-            else:
-                run_ts = read_orange(self.data_path, station_id=station_id, **kwargs)
+            return self._make_mth5_from_pr624(survey_id, station_id, **kwargs)
+
+        # For Orange Box, handle both single file and directory
+        data_path = Path(self.data_path)
+        if data_path.is_dir():
+            # Get all .BIN files in directory
+            bin_files = sorted(data_path.glob("*.BIN"))
+            if not bin_files:
+                raise FileNotFoundError(f"No .BIN files found in {data_path}")
+            run_ts = read_orange(bin_files, station_id=station_id, **kwargs)
+        else:
+            run_ts = read_orange(self.data_path, station_id=station_id, **kwargs)
 
         # Set run ID
         run_ts.run_metadata.id = run_id
@@ -171,6 +195,56 @@ class UoAClient(ClientBase):
             run_group.from_runts(run_ts)
             station_group.metadata.update(run_ts.station_metadata)
             station_group.write_metadata()
+            survey_group.update_metadata()
+
+        return self.save_path
+
+    def _make_mth5_from_pr624(self, survey_id, station_id, **kwargs):
+        """
+        Build the MTH5 run by run, using the collection to find the runs.
+
+        The collection knows where a recording stops and starts again.
+
+        :param survey_id: Survey identifier
+        :type survey_id: str
+        :param station_id: Station identifier
+        :type station_id: str
+        :param kwargs: Keyword arguments for :func:`mt_io.uoa.read_uoa`
+        :type kwargs: dict
+        :return: Path to created MTH5 file
+        :rtype: pathlib.Path
+        """
+
+        self.collection.survey_id = survey_id
+        for key in self._collection_keys:
+            if kwargs.get(key) is not None:
+                setattr(self.collection, key, kwargs[key])
+
+        # the collection selects on sample rate
+        if not self.sample_rates_given and kwargs.get("sample_rate") is not None:
+            self.sample_rates = [kwargs["sample_rate"]]
+
+        runs = self.get_run_dict()
+
+        with MTH5(**self.h5_kwargs) as m:
+            m.open_mth5(self.save_path, "w")
+            survey_group = m.add_survey(self.collection.survey_id)
+
+            for found_station, run_dict in runs.items():
+                station_group = survey_group.stations_group.add_station(
+                    found_station
+                )
+                for run_id, run_df in run_dict.items():
+                    run_group = station_group.add_run(run_id)
+                    run_ts = read_uoa(
+                        run_df.fn.to_list(), station_id=found_station, **kwargs
+                    )
+                    run_ts.run_metadata.id = run_id
+                    run_group.from_runts(run_ts)
+
+                station_group.metadata.update(run_ts.station_metadata)
+                station_group.write_metadata()
+
             survey_group.update_metadata()
 
         return self.save_path

--- a/mth5/groups/channel_dataset.py
+++ b/mth5/groups/channel_dataset.py
@@ -1049,11 +1049,12 @@ class ChannelDataset:
         >>> empty_channel.has_data()
         False
         """
-        if len(self.hdf5_dataset) > 0:
-            if len(np.nonzero(self.hdf5_dataset)[0]) > 0:
+        # scan in blocks and stop at the first non-zero sample rather
+        # than reading the whole channel back
+        step = 2**22
+        for start in range(0, len(self.hdf5_dataset), step):
+            if np.any(self.hdf5_dataset[start : start + step]):
                 return True
-            else:
-                return False
         return False
 
     def to_channel_ts(self) -> ChannelTS:

--- a/mth5/groups/standards.py
+++ b/mth5/groups/standards.py
@@ -29,6 +29,10 @@ from mth5.groups.base import BaseGroup
 from mth5.tables import MTH5Table
 from mth5.utils.exceptions import MTH5TableError
 
+# standards are static for the life of a process; summarizing them costs tens
+# of milliseconds and every new file asks for the same answer
+_STANDARDS_SUMMARY_CACHE: dict[tuple, np.ndarray] = {}
+
 
 ts_classes = dict(inspect.getmembers(timeseries, inspect.isclass))
 flt_classes = dict(inspect.getmembers(filters, inspect.isclass))
@@ -334,13 +338,23 @@ class StandardsGroup(BaseGroup):
         if modules is None:
             modules = self._modules
 
-        summaries = []
-        for module in modules:
-            summaries.append(
-                summarize_standards(module, output_type="array", dtype=STANDARDS_DTYPE)
-            )
+        key = tuple(modules)
+        cached = _STANDARDS_SUMMARY_CACHE.get(key)
+        if cached is None:
+            summaries = []
+            for module in modules:
+                summaries.append(
+                    summarize_standards(
+                        module, output_type="array", dtype=STANDARDS_DTYPE
+                    )
+                )
+            cached = np.concatenate(summaries)
+            _STANDARDS_SUMMARY_CACHE[key] = cached
 
-        return np.concatenate(summaries)
+        # the standards are static for the life of the process, so the
+        # summary is built once per module set; a copy keeps the cache
+        # safe from mutation by the caller
+        return cached.copy()
 
     def summary_table_from_array(self, array: np.ndarray) -> None:
         """
@@ -367,8 +381,7 @@ class StandardsGroup(BaseGroup):
         """
         summary_table = self._get_summary_table()
 
-        for index, row in enumerate(np.nditer(array)):
-            index = summary_table.add_row(row)
+        index = summary_table.add_rows(array)
         self.logger.debug(f"Added {index} rows to Standards Group")
 
     def initialize_group(self) -> None:

--- a/mth5/groups/standards.py
+++ b/mth5/groups/standards.py
@@ -29,8 +29,7 @@ from mth5.groups.base import BaseGroup
 from mth5.tables import MTH5Table
 from mth5.utils.exceptions import MTH5TableError
 
-# standards are static for the life of a process; summarizing them costs tens
-# of milliseconds and every new file asks for the same answer
+# the standards are static for the life of a process
 _STANDARDS_SUMMARY_CACHE: dict[tuple, np.ndarray] = {}
 
 
@@ -342,7 +341,7 @@ class StandardsGroup(BaseGroup):
         cached = _STANDARDS_SUMMARY_CACHE.get(key)
         if cached is None:
             summaries = []
-            for module in modules:
+            for module in key:
                 summaries.append(
                     summarize_standards(
                         module, output_type="array", dtype=STANDARDS_DTYPE
@@ -351,9 +350,7 @@ class StandardsGroup(BaseGroup):
             cached = np.concatenate(summaries)
             _STANDARDS_SUMMARY_CACHE[key] = cached
 
-        # the standards are static for the life of the process, so the
-        # summary is built once per module set; a copy keeps the cache
-        # safe from mutation by the caller
+        # a copy keeps the cache safe from mutation by the caller
         return cached.copy()
 
     def summary_table_from_array(self, array: np.ndarray) -> None:

--- a/mth5/tables/channel_table.py
+++ b/mth5/tables/channel_table.py
@@ -89,10 +89,12 @@ class ChannelSummaryTable(MTH5Table):
 
         def has_data(h5_dataset: h5py.Dataset) -> bool:
             """Return True when the dataset has any non-zero data."""
-            if len(h5_dataset) > 0:
-                if len(np.nonzero(h5_dataset)[0]) > 0:
+            # scan in blocks and stop at the first non-zero sample rather
+            # than reading the whole channel back
+            step = 2**22
+            for start in range(0, len(h5_dataset), step):
+                if np.any(h5_dataset[start : start + step]):
                     return True
-                return False
             return False
 
         def get_channel_entry(

--- a/mth5/tables/mth5_table.py
+++ b/mth5/tables/mth5_table.py
@@ -353,11 +353,79 @@ class MTH5Table:
             else:
                 new_shape = tuple([self.nrows + 1] + [ii for ii in self.shape[1:]])
                 self.array.resize(new_shape)
-        # add the row
+        # add the row.  The row is left out of the debug message on purpose:
+        # formatting a structured row is paid even when the message is dropped.
         self.array[index] = row
-        self.logger.debug(f"Added row as index {index} with values {row}")
+        self.logger.debug(f"Added row as index {index}")
 
         return index
+
+    def add_rows(self, rows: np.ndarray) -> int:
+        """
+        Add many rows in one resize and one write.
+
+        Parameters
+        ----------
+        rows : numpy.ndarray
+            Rows to append. Must have the same dtype (or same field names,
+            allowing safe casting) as the table.
+
+        Returns
+        -------
+        int
+            Index of the last row in the table.
+
+        Raises
+        ------
+        TypeError
+            If `rows` is not a `numpy.ndarray`.
+        ValueError
+            If the dtype is incompatible with the table.
+        """
+
+        if not isinstance(rows, np.ndarray):
+            msg = f"Input must be an numpy.ndarray not {type(rows)}"
+            self.logger.exception(msg)
+            raise TypeError(msg)
+        if not self.check_dtypes(rows.dtype):
+            if rows.dtype.names == self.dtype.names:
+                rows = rows.astype(self.dtype)
+            else:
+                msg = (
+                    f"Data types are not equal. Input dtypes: "
+                    f"{rows.dtype} Table dtypes: {self.dtype}"
+                )
+                self.logger.error(msg)
+                raise ValueError(msg)
+        # one row per leading index, whatever the table's row shape
+        rows = np.ascontiguousarray(rows).reshape((-1,) + tuple(self.shape[1:]))
+        n_rows = rows.shape[0]
+        if n_rows == 0:
+            return self.nrows - 1
+
+        start = self.nrows
+        # a fresh table holds a single null placeholder row; overwrite it
+        # rather than appending after it, the same way add_row does
+        if start == 1:
+            null_array = np.zeros(1, dtype=self.dtype)
+            if self.dtype.names is None:
+                raise TypeError("Table dtype must have named fields.")
+            match = True
+            for name in self.dtype.names:
+                if "reference" in name:
+                    continue
+                if self.array[name][0] != null_array[name][0]:
+                    match = False
+                    break
+            if match:
+                start = 0
+
+        new_shape = tuple([start + n_rows] + [ii for ii in self.shape[1:]])
+        self.array.resize(new_shape)
+        self.array[start:] = rows
+        self.logger.debug(f"Added {n_rows} rows ending at index {start + n_rows - 1}")
+
+        return start + n_rows - 1
 
     def update_row(self, entry: np.ndarray) -> int:
         """


### PR DESCRIPTION
Depends on IAGA-DVI-DataStandards/mt-io#6: item 2 imports UoACollection from there, so CI against the released mt-io will fail on that import until #6 merges. The other items are independent of it.

1. Bulk add_rows and one standards summary: the ~600-row standards summary table was written one h5py setitem per row, twice per file (file init and add_survey) and add_row formatted every row into a debug f-string even with logging off. Rows now write as one block and the summary array is built once per process and reused.

2. Split PR6-24 stations into runs: the UoA client now builds its file list through UoACollection (added in mt-io#6), so multi-run EDL stations come in as separate runs instead of one concatenated block.

3. Scan for data in blocks: has_data ran np.nonzero over entire channel datasets, so closing a file read every channel in full. It now scans ~4M-sample blocks and exits at the first nonzero.

4. Client metadata fixes: in phoenix.py the station update_metadata() call sat outside the station loop so only the last station was finalised and in metronix.py the survey update_metadata was referenced without parentheses.