### PR TITLE
Fix missing UTC (Z) suffix in Intermag requests

### DIFF
--- a/mth5/clients/intermag.py
+++ b/mth5/clients/intermag.py
@@ -10,7 +10,6 @@ import platform
 import sys
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
 
 # =============================================================================
@@ -479,10 +478,7 @@ class IntermagClient:
         ch = dict([(c.lower(), []) for c in self.elements])
         
         request_obj = self._request_data(
-            self._get_request_dictionary(
-                np.datetime64(self._start.iso_no_tz), 
-                np.datetime64(self._end.iso_no_tz)
-            )
+            self._get_request_dictionary(self.start, self.end)
         )
         if request_obj.status_code == 200:
             request_json = json.loads(request_obj.content)


### PR DESCRIPTION
## Summary

`IntermagClient.get_data()` built the outgoing BGS GIN service request from
`np.datetime64(self._start.iso_no_tz)` / `np.datetime64(self._end.iso_no_tz)`,
which strips the `Z` (UTC) suffix that `self.start`/`self.end` already
correctly append. BGS rejects timestamps without that suffix with a
`400 Bad date format` error, so `MakeMTH5.from_intermag()` failed on every
call.

## Fix

Use the existing `self.start`/`self.end` properties instead of re-deriving
timestamps from the private `_start`/`_end` `MTime` objects. Also drops the
now-unused `numpy` import.

## Context

Found while investigating #188 (USGS geomag webservice returning all-NaN
data -- `from_intermag` is the recommended replacement source, but couldn't
even get past the initial request without this fix). See the follow-up
comment on #188 for other related findings (FRD's native H/D/Z orientation
vs. the client's x/y/z-only channel map, and a revived "Beatles test" in
aurora tracking the deeper generic-channel-name limitation).

Small, surgical fix -- happy to discuss further on the next mth5 call.